### PR TITLE
use the html file on disk at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 pico_sdk_init()
 
+set(STATIC_HTML_PATH "" CACHE PATH "Directory of static HTML file" PARENT_SCOPE)
+set(STATIC_HTML_FILENAME "" CACHE PATH "Filename of static HTML file" PARENT_SCOPE)
+mark_as_advanced(STATIC_HTML_PATH)
+mark_as_advanced(STATIC_HTML_FILENAME)
+
 add_library(pico_ws_server
   src/client_connection.cpp
   src/http_handler.cpp
@@ -17,8 +22,16 @@ add_library(pico_ws_server
   src/web_socket_server_internal.cpp
 )
 
+if(NOT STATIC_HTML_PATH)
+    message(FATAL_ERROR "STATIC_HTML_PATH must be set")
+endif()
+if(NOT STATIC_HTML_FILENAME)
+    message(FATAL_ERROR "STATIC_HTML_FILENAME must be set")
+endif()
+
 target_include_directories(pico_ws_server PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include )
 target_include_directories(pico_ws_server PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src )
+target_include_directories(pico_ws_server PRIVATE ${PROJECT_BINARY_DIR})
 
 target_compile_definitions(pico_ws_server PUBLIC DEBUG_PRINT=0)
 
@@ -30,8 +43,17 @@ target_link_libraries(pico_ws_server
   lwipopts_provider
 )
 
-if (DEFINED PICO_WS_SERVER_STATIC_HTML_HEX)
-  target_compile_definitions(pico_ws_server PRIVATE
-    PICO_WS_SERVER_STATIC_HTML_HEX="${PICO_WS_SERVER_STATIC_HTML_HEX}"
-  )
-endif()
+add_custom_command(
+    OUTPUT ${PROJECT_BINARY_DIR}/static_html_hex.h
+    DEPENDS ${STATIC_HTML_PATH}
+    COMMAND gzip --best -c ${STATIC_HTML_PATH}/${STATIC_HTML_FILENAME} > ${PROJECT_BINARY_DIR}/static.html.gz
+    COMMAND ${CMAKE_COMMAND} -E echo "\\#ifndef STATIC_HTML_HEX" >> ${PROJECT_BINARY_DIR}/static_html_hex.h
+    COMMAND ${CMAKE_COMMAND} -E echo "\\#define STATIC_HTML_HEX" >> ${PROJECT_BINARY_DIR}/static_html_hex.h
+    COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} xxd -i static.html.gz >> ${PROJECT_BINARY_DIR}/static_html_hex.h
+    COMMAND ${CMAKE_COMMAND} -E echo "\\#endif // STATIC_HTML_HEX" >> ${PROJECT_BINARY_DIR}/static_html_hex.h
+)
+
+add_custom_target(generate_static_html_hex ALL
+    DEPENDS ${PROJECT_BINARY_DIR}/static_html_hex.h
+)
+add_dependencies(pico_ws_server generate_static_html_hex)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This server does not currently support HTTPS/WSS
 ## HTTP Notes
 This does not aim to be a general-purpose HTTP server, and only includes minimal HTTP support for the WebSocket handshake. Only `GET / HTTP/1.1` requests are allowed, all other requests will return status `400`/`404`/`405`.
 
-Valid requests which do not request a WebSocket upgrade will be served a static HTML blob. This is defined at compile time via CMake, using `PICO_WS_SERVER_STATIC_HTML_HEX` ([see example](example/CMakeLists.txt)).
+Valid requests which do not request a WebSocket upgrade will be served a static HTML blob. This is defined at compile time via CMake, using the specified file ([see example](example/CMakeLists.txt)). Define `STATIC_HTML_PATH` to point at the directory containing the static HTML, and `STATIC_HTML_FILENAME` as the static HTML filename. Changes to the HTML file will get added at compile time.
 
 ## Performance Notes
 No benchmarking has been done, but this server is expected to have a small memory footprint and low response latency. However, there is likely room for performance improvement when it comes to processing large payloads.

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,13 +4,14 @@ set(PICO_BOARD pico_w)
 
 include(../pico_sdk_import.cmake)
 
-file(READ static.html PICO_WS_SERVER_STATIC_HTML_HEX HEX)
-add_subdirectory(.. pico-ws-server)
-
 project(ws_server_example C CXX ASM)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 pico_sdk_init()
+
+set(STATIC_HTML_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+set(STATIC_HTML_FILENAME "static.html")
+add_subdirectory(.. pico-ws-server)
 
 add_library(lwipopts_provider INTERFACE)
 target_include_directories(lwipopts_provider INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/src/http_handler.cpp
+++ b/src/http_handler.cpp
@@ -109,7 +109,7 @@ bool HTTPHandler::sendHTML() {
     return false;
   }
   char len_string[32];
- snprintf(len_string, sizeof(len_string), "%d", static_html_gz_len);
+  snprintf(len_string, sizeof(len_string), "%d", static_html_gz_len);
   if (!sendString(len_string)) {
     return false;
   }


### PR DESCRIPTION
no need for extra allocation
gzip, so less memory/faster transfer
when html file changes build picks it up