### PR TITLE
Add support for custom/user handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ mark_as_advanced(STATIC_HTML_FILENAME)
 add_library(pico_ws_server
   src/client_connection.cpp
   src/http_handler.cpp
+  src/http_request.cpp
   src/web_socket_frame_builder.cpp
   src/web_socket_handler.cpp
   src/web_socket_message_builder.cpp

--- a/include/pico_ws_server/web_socket_server.h
+++ b/include/pico_ws_server/web_socket_server.h
@@ -14,6 +14,7 @@ class WebSocketServer {
   // Note: data can be treated as a null-terminated string if expecting TEXT messages (an extra NULL byte is allocated)
   typedef void (*MessageCallback)(WebSocketServer& server, uint32_t conn_id, const void *data, size_t len);
   typedef void (*CloseCallback)(WebSocketServer& server, uint32_t conn_id);
+  typedef bool (*UserCallback)(WebSocketServer& server, uint32_t conn_id, struct pbuf* pb, void* context);
 
   WebSocketServer(uint32_t max_connections = 1);
   ~WebSocketServer();
@@ -28,6 +29,8 @@ class WebSocketServer {
   void setCallbackExtra(void* arg);
   void* getCallbackExtra();
 
+  void setUserCallback(UserCallback cb, void* context = nullptr);
+
   bool startListening(uint16_t port);
   // Must be called routinely to process incoming messages (triggers message callback)
   void popMessages();
@@ -41,6 +44,9 @@ class WebSocketServer {
   bool broadcastMessage(const char* payload);
   // Send a BINARY message to all connections
   bool broadcastMessage(const void* payload, size_t payload_size);
+
+  // Send an raw (non-websocket) message
+  bool sendRaw(uint32_t conn_id, const char* payload, size_t payload_size);
 
   // Begin closing the specified connection.
   // Note: it is still possible for messages to be received on a closing connection,

--- a/src/client_connection.cpp
+++ b/src/client_connection.cpp
@@ -22,6 +22,8 @@ bool ClientConnection::process(struct pbuf* pb) {
   bool result;
   if (http_handler.isUpgraded()) {
     result = ws_handler.process(pb);
+  } else if (server.onUser(this, pb)) {
+    result = true;
   } else {
     result = http_handler.process(pb);
     if (http_handler.isUpgraded()) {

--- a/src/client_connection.h
+++ b/src/client_connection.h
@@ -38,6 +38,7 @@ class ClientConnection {
  private:
   WebSocketServerInternal& server;
   struct tcp_pcb* pcb;
+  bool is_upgraded = false;
   HTTPHandler http_handler;
   WebSocketHandler ws_handler;
 

--- a/src/http_handler.h
+++ b/src/http_handler.h
@@ -7,51 +7,25 @@
 #include "lwip/pbuf.h"
 
 class ClientConnection;
+class HTTPRequest;
 
 // Only access from lwIP context
 class HTTPHandler {
  public:
   HTTPHandler(ClientConnection& connection) : connection(connection) {}
 
-  bool process(struct pbuf* pb);
-  bool isUpgraded() { return is_upgraded; }
+  bool process(struct pbuf* pb, bool *is_upgraded);
   bool isClosing() { return is_closing; }
 
  private:
-  static constexpr auto HEADER_BUF_SIZE = 64;
-
-  enum RequestPart {
-    METHOD,
-    PATH,
-    PROTOCOL,
-    HEADER,
-    LINE_DELIM,
-  };
-
   ClientConnection& connection;
-  bool is_upgraded = false;
   bool is_closing = false;
-
-  size_t request_bytes = 0;
-  RequestPart current_part = METHOD;
-  size_t current_index = 0;
-
-  char current_header[HEADER_BUF_SIZE] = {0};
-
-  bool has_upgrade_header = false;
-  bool has_connection_header = false;
-  bool has_ws_version_header = false;
-  char ws_key_header_value[HEADER_BUF_SIZE] = {0};
 
   bool send(const void* data, size_t size);
   bool sendString(const char* s);
   bool sendHTML();
   bool sendUpgradeResponse(uint8_t* key_accept, size_t key_accept_len);
-  bool attemptUpgrade(bool* sent_html);
-
-  bool matchAndThen(char c, const char* expected, RequestPart next_part);
-  bool processHeader(const char* header);
-  bool process(char c, bool* sent_html);
+  bool attemptUpgrade(const HTTPRequest& request, bool* sent_html);
 };
 
 #endif

--- a/src/http_request.cpp
+++ b/src/http_request.cpp
@@ -1,0 +1,117 @@
+#include "http_request.h"
+
+#include <string.h>
+
+#include "lwip/pbuf.h"
+
+namespace {
+
+static constexpr auto MAX_REQUEST_SIZE = 4096;
+
+static constexpr auto HEADER_BUF_SIZE = 64;
+static constexpr const char EXPECTED_METHOD[] = "GET ";
+static constexpr const char EXPECTED_PATH[] = "/ ";
+static constexpr const char EXPECTED_PROTOCOL[] = "HTTP/1.1\r\n";
+static constexpr const char EXPECTED_HEADER_UPGRADE[] = "Upgrade: websocket";
+static constexpr const char EXPECTED_HEADER_CONNECTION_KEY[] = "Connection: ";
+static constexpr const char EXPECTED_HEADER_CONNECTION_VALUE[] = "Upgrade";
+static constexpr const char EXPECTED_HEADER_WS_VERSION[] = "Sec-WebSocket-Version: 13";
+static constexpr const char EXPECTED_HEADER_NAME_WS_KEY[] = "Sec-WebSocket-Key: ";
+
+} // namespace
+
+HTTPRequest::ProcessResult HTTPRequest::process(struct pbuf* pb) {
+  request_bytes = 0;
+  for (size_t i = 0; i < pb->tot_len; ++i) {
+    char c = pbuf_get_at(pb, i);
+    bool sent_response;
+    const auto result = process(c);
+    switch (result) {
+      case CONTINUE:
+        continue;
+      default:
+        return result;
+    }
+  }
+  return BAD_REQUEST;
+}
+
+bool HTTPRequest::matchAndThen(char c, const char* expected, RequestPart next_part) {
+    if (c != expected[current_index++]) {
+      current_index = 0;
+      return false;
+    }
+    if (!expected[current_index]) {
+      current_part = next_part;
+      current_index = 0;
+    }
+    return true;
+}
+
+void HTTPRequest::processHeader(const char* header) {
+  if (!strcmp(header, EXPECTED_HEADER_UPGRADE)) {
+    has_upgrade_header = true;
+  }
+  if (!strncmp(header, EXPECTED_HEADER_CONNECTION_KEY, strlen(EXPECTED_HEADER_CONNECTION_KEY))) {
+    if (strstr(header + strlen(EXPECTED_HEADER_CONNECTION_KEY), EXPECTED_HEADER_CONNECTION_VALUE)) {
+      has_connection_header = true;
+    }
+  }
+  if (!strcmp(header, EXPECTED_HEADER_WS_VERSION)) {
+    has_ws_version_header = true;
+  }
+  if (!strncmp(header, EXPECTED_HEADER_NAME_WS_KEY, strlen(EXPECTED_HEADER_NAME_WS_KEY))) {
+    strcpy(ws_key_header_value, header + strlen(EXPECTED_HEADER_NAME_WS_KEY));
+  }
+}
+
+HTTPRequest::ProcessResult HTTPRequest::process(char c) {
+    if (++request_bytes > MAX_REQUEST_SIZE) {
+      return BAD_REQUEST;
+    }
+  
+    switch (current_part) {
+    case METHOD:
+      if (!matchAndThen(c, EXPECTED_METHOD, PATH)) {
+        return BAD_METHOD;
+      }
+      return CONTINUE;
+  
+    case PATH:
+      if (!matchAndThen(c, EXPECTED_PATH, PROTOCOL)) {
+        return NOT_FOUND;
+      }
+      return CONTINUE;
+  
+    case PROTOCOL:
+      if (!matchAndThen(c, EXPECTED_PROTOCOL, HEADER)) {
+        return BAD_REQUEST;
+      }
+      return CONTINUE;
+  
+    case HEADER:
+      if (c == '\r') {
+        current_part = LINE_DELIM;
+        current_index = 0;
+      } else if (current_index < HEADER_BUF_SIZE - 1) {
+        current_header[current_index++] = c;
+        current_header[current_index] = 0;
+      }
+      return CONTINUE;
+  
+    case LINE_DELIM:
+      if (c != '\n') {
+        return BAD_REQUEST;
+      }
+      if (!current_header[0]) {
+        return ATTEMPT_UPGRADE;
+      }
+      processHeader(current_header);
+      current_part = HEADER;
+      current_index = 0;
+      current_header[0] = 0;
+      return CONTINUE;
+    }
+
+    return BAD_REQUEST;
+}

--- a/src/http_request.h
+++ b/src/http_request.h
@@ -1,0 +1,50 @@
+#ifndef __HTTP_REQUEST_H__
+#define __HTTP_REQUEST_H__
+
+#include <cstddef>
+
+class HTTPRequest {
+ public:
+  enum ProcessResult {
+    CONTINUE,
+    BAD_REQUEST,
+    BAD_METHOD,
+    NOT_FOUND,
+    ATTEMPT_UPGRADE,
+  };
+
+  HTTPRequest() {}
+  ~HTTPRequest() {}
+ 
+  ProcessResult process(struct pbuf* pb);
+
+ private:
+  friend class HTTPHandler;
+
+  static constexpr auto HEADER_BUF_SIZE = 64;
+
+  enum RequestPart {
+    METHOD,
+    PATH,
+    PROTOCOL,
+    HEADER,
+    LINE_DELIM,
+  };
+
+  size_t request_bytes = 0;
+  RequestPart current_part = METHOD;
+  size_t current_index = 0;
+
+  char current_header[HEADER_BUF_SIZE] = {0};
+
+  bool has_upgrade_header = false;
+  bool has_connection_header = false;
+  bool has_ws_version_header = false;
+  char ws_key_header_value[HEADER_BUF_SIZE] = {0};
+
+  bool matchAndThen(char c, const char* expected, RequestPart next_part);
+  void processHeader(const char* header);
+  ProcessResult process(char c);
+};
+
+#endif

--- a/src/web_socket_server.cpp
+++ b/src/web_socket_server.cpp
@@ -24,6 +24,9 @@ void WebSocketServer::setCallbackExtra(void* arg) {
 void* WebSocketServer::getCallbackExtra() {
   return callback_extra;
 }
+void WebSocketServer::setUserCallback(UserCallback cb, void* context) {
+  internal->setUserCallback(cb, context);
+}
 
 bool WebSocketServer::startListening(uint16_t port) {
   return internal->startListening(port);
@@ -44,6 +47,10 @@ bool WebSocketServer::broadcastMessage(const char* payload) {
 }
 bool WebSocketServer::broadcastMessage(const void* payload, size_t payload_size) {
   return internal->broadcastMessage(payload, payload_size);
+}
+
+bool WebSocketServer::sendRaw(uint32_t conn_id, const char* payload, size_t payload_size) {
+  return internal->sendRaw(conn_id, payload, payload_size);
 }
 
 bool WebSocketServer::close(uint32_t conn_id) {

--- a/src/web_socket_server_internal.h
+++ b/src/web_socket_server_internal.h
@@ -19,6 +19,10 @@ class WebSocketServerInternal {
   void setConnectCallback(WebSocketServer::ConnectCallback cb) { connect_cb = cb; }
   void setCloseCallback(WebSocketServer::CloseCallback cb) { close_cb = cb; }
   void setMessageCallback(WebSocketServer::MessageCallback cb) { message_cb = cb; }
+  void setUserCallback(WebSocketServer::UserCallback cb, void* context) {
+    user_cb = cb;
+    user_cb_context = context;
+  }
 
   bool startListening(uint16_t port);
   void popMessages();
@@ -28,6 +32,8 @@ class WebSocketServerInternal {
   bool broadcastMessage(const char* payload);
   bool broadcastMessage(const void* payload, size_t payload_size);
 
+  bool sendRaw(uint32_t conn_id, const char* payload, size_t payload_size);
+
   bool close(uint32_t conn_id);
 
   ClientConnection* onConnect(struct tcp_pcb* pcb);
@@ -36,6 +42,8 @@ class WebSocketServerInternal {
 
   void onMessage(ClientConnection* connection, const void* payload, size_t size);
 
+  bool onUser(ClientConnection* connection, struct pbuf* pb);
+
  private:
   WebSocketServer& server;
 
@@ -43,6 +51,8 @@ class WebSocketServerInternal {
   WebSocketServer::ConnectCallback connect_cb = nullptr;
   WebSocketServer::MessageCallback message_cb = nullptr;
   WebSocketServer::CloseCallback close_cb = nullptr;
+  WebSocketServer::UserCallback user_cb = nullptr;
+  void* user_cb_context = nullptr;
 
   struct tcp_pcb* listen_pcb = nullptr;
   std::unordered_map<uint32_t, std::unique_ptr<ClientConnection>> connection_by_id;


### PR DESCRIPTION
This adds support to provide a custom handler for any kind of requests.
I use this to add support for a template engine.

Also does some code-reorganization to handle websocket messages as well as http requests simultaneously.

What do you think?