### PR TITLE
Fix: prevent 0-length frames from consuming next frame's first byte

### DIFF
--- a/src/web_socket_frame_builder.cpp
+++ b/src/web_socket_frame_builder.cpp
@@ -134,7 +134,12 @@ bool WebSocketFrameBuilder::process(uint8_t byte) {
     frame = std::make_unique<WebSocketFrame>(getOpcode(header), isFinal(header), payload_size);
   }
 
-  if (!consumed) {
+  // Only append byte to payload if:
+  // 1. The byte wasn't consumed by header parsing
+  // 2. The frame actually has a payload (payload_size > 0)
+  // Without the payload_size check, 0-length frames (like CLOSE) would incorrectly
+  // append the first byte of the next frame to their payload
+  if (!consumed && payload_size > 0) {
     frame->append(byte);
     consumed = true;
   }


### PR DESCRIPTION
WebSocket frames with no payload (like CLOSE) were incorrectly appending the first byte of the following frame to their payload. Added a payload_size check before appending bytes to ensure only frames that expect payload data will consume incoming bytes.